### PR TITLE
perf: Use `preserveParens` parse option to skip `visitNode` task

### DIFF
--- a/src/visitor-keys.ts
+++ b/src/visitor-keys.ts
@@ -141,5 +141,4 @@ export const visitorKeys: Record<string, string[] | undefined> = {
   TSTypeReference: ["typeName", "typeArguments"],
   TSUnionType: ["types"],
   ParenthesizedExpression: ["expression"],
-  TSParenthesizedType: ["typeAnnotation"],
 };


### PR DESCRIPTION
I think the impact will be slight, but better than nothing. 😃